### PR TITLE
Record parse failure reason and location

### DIFF
--- a/.github/workflows/ubuntu24.yml
+++ b/.github/workflows/ubuntu24.yml
@@ -4,20 +4,20 @@ on: [push, pull_request]
 
 jobs:
   ubuntu-build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - name: Use cmake
         run: |
           mkdir build &&
           cd build &&
-          CXX=g++-13 CXXFLAGS=-Werror cmake -DFASTFLOAT_TEST=ON  ..  &&
+          CXXFLAGS=-Werror cmake -DFASTFLOAT_TEST=ON  ..  &&
           cmake --build .   &&
           ctest --output-on-failure
       - name: Use cmake CXX23
         run: |
           mkdir build20 &&
           cd build20 &&
-          CXX=g++-13 CXXFLAGS=-Werror cmake -DFASTFLOAT_CONSTEXPR_TESTS=ON -DFASTFLOAT_FIXEDWIDTH_TESTS=ON -DFASTFLOAT_CXX_STANDARD=23 -DFASTFLOAT_TEST=ON  ..  &&
+          CXXFLAGS=-Werror cmake -DFASTFLOAT_CONSTEXPR_TESTS=ON -DFASTFLOAT_FIXEDWIDTH_TESTS=ON -DFASTFLOAT_CXX_STANDARD=23 -DFASTFLOAT_TEST=ON  ..  &&
           cmake --build .   &&
           ctest --output-on-failure

--- a/.github/workflows/ubuntu24.yml
+++ b/.github/workflows/ubuntu24.yml
@@ -1,4 +1,4 @@
-name: Ubuntu 22.04 CI (GCC 13)
+name: Ubuntu 24.04 CI (GCC 13)
 
 on: [push, pull_request]
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.9)
 
-project(fast_float VERSION 6.1.1 LANGUAGES CXX)
+project(fast_float VERSION 6.1.2 LANGUAGES CXX)
 set(FASTFLOAT_CXX_STANDARD 11 CACHE STRING "the C++ standard to use for fastfloat")
 set(CMAKE_CXX_STANDARD ${FASTFLOAT_CXX_STANDARD})
 option(FASTFLOAT_TEST "Enable tests" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.9)
 
-project(fast_float VERSION 6.1.2 LANGUAGES CXX)
+project(fast_float VERSION 6.1.3 LANGUAGES CXX)
 set(FASTFLOAT_CXX_STANDARD 11 CACHE STRING "the C++ standard to use for fastfloat")
 set(CMAKE_CXX_STANDARD ${FASTFLOAT_CXX_STANDARD})
 option(FASTFLOAT_TEST "Enable tests" OFF)

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ the command line help.
 
 You may directly download automatically generated single-header files:
 
-https://github.com/fastfloat/fast_float/releases/download/v6.1.1/fast_float.h
+https://github.com/fastfloat/fast_float/releases/download/v6.1.2/fast_float.h
 
 ## RFC 7159
 

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ the command line help.
 
 You may directly download automatically generated single-header files:
 
-https://github.com/fastfloat/fast_float/releases/download/v6.1.2/fast_float.h
+https://github.com/fastfloat/fast_float/releases/download/v6.1.3/fast_float.h
 
 ## RFC 7159
 

--- a/include/fast_float/ascii_number.h
+++ b/include/fast_float/ascii_number.h
@@ -349,7 +349,7 @@ parsed_number_string_t<UC> parse_number_string(UC const *p, UC const * pend, par
       ++p;
     }
     if ((p == pend) || !is_integer(*p)) {
-      if(!(fmt & chars_format::fixed) || (fmt & FASTFLOAT_JSONFMT)) {
+      if(!(fmt & chars_format::fixed)) {
         // We are in error.
         return answer;
       }

--- a/include/fast_float/decimal_to_binary.h
+++ b/include/fast_float/decimal_to_binary.h
@@ -127,8 +127,9 @@ adjusted_mantissa compute_float(int64_t q, uint64_t w)  noexcept  {
   // but in practice, we can win big with the compute_product_approximation if its additional branch
   // is easily predicted. Which is best is data specific.
   int upperbit = int(product.high >> 63);
+  int shift = upperbit + 64 - binary::mantissa_explicit_bits() - 3;
 
-  answer.mantissa = product.high >> (upperbit + 64 - binary::mantissa_explicit_bits() - 3);
+  answer.mantissa = product.high >> shift;
 
   answer.power2 = int32_t(detail::power(int32_t(q)) + upperbit - lz - binary::minimum_exponent());
   if (answer.power2 <= 0) { // we have a subnormal?
@@ -164,7 +165,7 @@ adjusted_mantissa compute_float(int64_t q, uint64_t w)  noexcept  {
     // To be in-between two floats we need that in doing
     //   answer.mantissa = product.high >> (upperbit + 64 - binary::mantissa_explicit_bits() - 3);
     // ... we dropped out only zeroes. But if this happened, then we can go back!!!
-    if((answer.mantissa  << (upperbit + 64 - binary::mantissa_explicit_bits() - 3)) ==  product.high) {
+    if((answer.mantissa  << shift) ==  product.high) {
       answer.mantissa &= ~uint64_t(1);          // flip it so that we do not round up
     }
   }

--- a/script/release.py
+++ b/script/release.py
@@ -16,7 +16,7 @@ def colored(r, g, b, text):
     return "\033[38;2;{};{};{}m{} \033[38;2;255;255;255m".format(r, g, b, text)
 
 def extractnumbers(s):
-    return tuple(map(int,re.findall("(\d+)\.(\d+)\.(\d+)",str(s))[0]))
+    return tuple(map(int,re.findall(r"(\d+)\.(\d+)\.(\d+)",str(s))[0]))
 
 def toversionstring(major, minor, rev):
     return str(major)+"."+str(minor)+"."+str(rev)
@@ -90,7 +90,7 @@ cmakefile = maindir + os.sep + "CMakeLists.txt"
 
 
 for line in fileinput.input(cmakefile, inplace=1, backup='.bak'):
-    line = re.sub('project\(fast_float VERSION \d+\.\d+\.\d+ LANGUAGES CXX\)','project(fast_float VERSION '+newmajorversionstring+'.'+mewminorversionstring+'.'+newrevversionstring+" LANGUAGES CXX)", line.rstrip())
+    line = re.sub(r'project\(fast_float VERSION \d+\.\d+\.\d+ LANGUAGES CXX\)','project(fast_float VERSION '+newmajorversionstring+'.'+mewminorversionstring+'.'+newrevversionstring+" LANGUAGES CXX)", line.rstrip())
     print(line)
 
 print("modified "+cmakefile+", a backup was made")
@@ -100,7 +100,7 @@ readmefile = maindir + os.sep + "README.md"
 
 
 for line in fileinput.input(readmefile, inplace=1, backup='.bak'):
-    line = re.sub('https://github.com/fastfloat/fast_float/releases/download/v(\d+\.\d+\.\d+)/fast_float.h','https://github.com/fastfloat/fast_float/releases/download/v'+newmajorversionstring+'.'+mewminorversionstring+'.'+newrevversionstring+'/fast_float.h', line.rstrip())
+    line = re.sub(r'https://github.com/fastfloat/fast_float/releases/download/v(\d+\.\d+\.\d+)/fast_float.h','https://github.com/fastfloat/fast_float/releases/download/v'+newmajorversionstring+'.'+mewminorversionstring+'.'+newrevversionstring+'/fast_float.h', line.rstrip())
     print(line)
 
 print("modified "+readmefile+", a backup was made")


### PR DESCRIPTION
In parse_number_string, if there is a parse error, report the specific error as one of the values in a new parse_error enum, and update lastmatch to match the error location. This allows users of the library to print more helpful error messages for invalid inputs.